### PR TITLE
[Fix] 관리자 리스트페이지 디자인 통일 및 통계데이터 추가 (#53)

### DIFF
--- a/src/components/MyProfileContentsShop.vue
+++ b/src/components/MyProfileContentsShop.vue
@@ -5,15 +5,15 @@
         <div class="my_clm">
             <dl>
                 <dt>취소</dt>
-                <dd><a href="javascript:overpass.link('MYCLAIM', {ord_crt_divi_cd:'20'});" id="claim_cancel">0<em class="ir"></em></a></dd>
+                <dd><a href="#" id="claim_cancel">0<em class="ir"></em></a></dd>
             </dl>
             <dl>
                 <dt>교환</dt>
-                <dd><a href="javascript:overpass.link('MYCLAIM', {ord_crt_divi_cd:'40'});" id="claim_exchng">0<em class="ir"></em></a></dd>
+                <dd><a href="#" id="claim_exchng">0<em class="ir"></em></a></dd>
             </dl>
             <dl>
                 <dt>반품</dt>
-                <dd><a href="javascript:overpass.link('MYCLAIM', {ord_crt_divi_cd:'30'});" id="claim_return">0<em class="ir"></em></a></dd>
+                <dd><a href="#" id="claim_return">0<em class="ir"></em></a></dd>
             </dl>
         </div>
         
@@ -22,27 +22,27 @@
             <div class="m_step">
                 <dl class="s1">
                     <dt>결제대기</dt>
-                    <dd><a code="goOrderList" href="javascript:overpass.link('MYORDER');" id="pay_wait"></a></dd>
+                    <dd><a code="goOrderList" href="#" id="pay_wait"></a></dd>
                 </dl>
                 <dl class="s2">
                     <dt>결제완료</dt>
-                    <dd><a code="goOrderList" href="javascript:overpass.link('MYORDER');" id="pay_fini"></a></dd>
+                    <dd><a code="goOrderList" href="#" id="pay_fini"></a></dd>
                 </dl>
                 <dl class="s3">
                     <dt>상품준비중</dt>
-                    <dd><a code="goOrderList" href="javascript:overpass.link('MYORDER');" id="ship_indi"></a></dd>
+                    <dd><a code="goOrderList" href="#" id="ship_indi"></a></dd>
                 </dl>
                 <dl class="s4">
                     <dt>물류센터이동중</dt>
-                    <dd><a code="goOrderList" href="javascript:overpass.link('MYORDER');" id="ship_ing"></a></dd>
+                    <dd><a code="goOrderList" href="#" id="ship_ing"></a></dd>
                 </dl>
                 <dl class="s5">
                     <dt>배송중</dt>
-                    <dd><a code="goOrderList" href="javascript:overpass.link('MYORDER');" id="deli_ing"></a></dd>
+                    <dd><a code="goOrderList" href="#" id="deli_ing"></a></dd>
                 </dl>
                 <dl class="s6">
                     <dt>배송완료</dt>
-                    <dd><a code="goOrderList" href="javascript:overpass.link('MYORDER');" id="deli_fini"></a></dd>
+                    <dd><a code="goOrderList" href="#" id="deli_fini"></a></dd>
                 </dl>
             </div>
             <div class="m_clm">
@@ -54,27 +54,27 @@
         <div class="my_stat">
             <dl>
                 <dt><span class="dt">상품리뷰</span></dt>
-                <dd><span class="dd">미작성 <a href="javascript:overpass.link('MYREV');">0</a></span></dd>
+                <dd><span class="dd">미작성 <a href="#">0</a></span></dd>
             </dl>
             <dl>
                 <dt><span class="dt">상품문의</span></dt>
                 <dd>
-                    <span class="dd">작성<a href="javascript:overpass.link('MYQNA');">0</a></span>
-                    <span class="dd">답변<a href="javascript:overpass.link('MYQNA');">0</a></span>
+                    <span class="dd">작성<a href="#">0</a></span>
+                    <span class="dd">답변<a href="#">0</a></span>
                 </dd>
             </dl>
             <dl>
                 <dt><span class="dt">1:1 문의내역</span></dt>
                 <dd>
-                    <span class="dd">작성 <a href="javascript:overpass.link('MYCONTACT');">0</a></span>
-                    <span class="dd">답변 <a href="javascript:overpass.link('MYCONTACT');">0</a></span>
+                    <span class="dd">작성 <a href="#">0</a></span>
+                    <span class="dd">답변 <a href="#">0</a></span>
                 </dd>
             </dl>
             <dl>
                 <dt><span class="dt">이벤트참여내역</span></dt>
                 <dd>
-                    <span class="dd">응모<a href="javascript:overpass.link('MYEVENT');">0</a></span>
-                    <span class="dd">당첨<a href="javascript:overpass.link('MYEVENT');">0</a></span>
+                    <span class="dd">응모<a href="#">0</a></span>
+                    <span class="dd">당첨<a href="#">0</a></span>
                 </dd>
             </dl>
         </div>

--- a/src/components/modal/ComplaintDetailModal.vue
+++ b/src/components/modal/ComplaintDetailModal.vue
@@ -2,9 +2,9 @@
 <template>
   <div v-if="isModalComplaintDetailOpen" class="modal">
     <div class="modal-content" @click.stop>
-      <div class="modal-header">
+      <div class="modal-header relative">
         <h2 style="font-size: 24px; font-weight: bold; color:#EFEFEF">계정 상세 정보</h2>
-        <span class="close" @click="closeComplaintDetailModal(selectedComplaintId)">&times;</span>
+        <span class="close absolute" @click="closeComplaintDetailModal(selectedComplaintId)">&times;</span>
       </div>
         <div v-if="loading" class="loading-text">
           로딩 중...
@@ -34,8 +34,8 @@
           <h3 style="font-size: 20px; font-weight: bold; margin-top: 10px; margin-bottom: 5px;">사진</h3>
           <div class="rounded-table">
             <div class="flex flex-row flex-wrap p-2 h-auto">
-              <div v-for="image in urls" :key="image.files" class="mt-2 max-w-[100px] max-h-[100px] rounded-md flex-shrink-0">
-                <img :src="image" alt="선택된 이미지" class="w-full h-full object-cover aspect-w-1 aspect-h-1 p-1">
+              <div v-for="image in urls" :key="image" class="mt-2 max-w-[100px] max-h-[100px] rounded-md flex-shrink-0">
+                <img :src="image" alt="선택된 이미지" @click="openImageDetailModal(image)" style="cursor: pointer;" class="w-full h-full object-cover aspect-w-1 aspect-h-1 p-1">
               </div>
             </div>
           </div>
@@ -52,14 +52,24 @@
           </div>
           <button v-if="!isUpdating && click" @click="updateComment(selectedComplaintId)" class="hover:bg-orange-600 text-white py-3 px-6 rounded" style="width: 100px; background-color: #F5A742;">수정완료</button>
         </div>
+        <div class="modal-content" @click.stop>
+          <div class="modal-inner">
+            <ImageModal :isModalImageDetailOpen="isModalImageDetailOpen" :selectedImageUrl="selectedImageUrl" @close-modal="isModalImageDetailOpen = false" />
+          </div>
+        </div>
       </div>
+
   </div>
 </template>
 
 <script>
 import axios from 'axios';
 import no_images from '@/assets/images/no_image.png'
+import ImageModal from '@/components/modal/ImageModal.vue';
 export default {
+  components: {
+    ImageModal
+  },
   props: ['selectedComplaintId', 'isModalComplaintDetailOpen'],
   data() {
     return {
@@ -82,7 +92,9 @@ export default {
                 { id: 'myinfo', value: 'MYINFO', label: '회원정보' },
                 { id: 'confirmation', value: 'CONFIRMATION', label: '상품확인' },
                 { id: 'service', value: 'SERVICE', label: '서비스' }
-      ]
+      ],
+      selectedImageUrl: '',
+      isModalImageDetailOpen: false,
     };
   },
   watch: {
@@ -223,7 +235,16 @@ export default {
         this.isUpdating = false;
         this.isEditing = false;
       }
-    }
+    },
+    // 모달 열기
+    openImageDetailModal(url) {
+      this.selectedImageUrl = url;
+      this.isModalImageDetailOpen = true;
+    },
+    closeImageDetailModal() {
+      this.isModalImageDetailOpen = false;
+      console.log(this.isModalImageDetailOpen);
+    },
   },
 };
 </script>

--- a/src/components/modal/ImageModal.vue
+++ b/src/components/modal/ImageModal.vue
@@ -1,0 +1,105 @@
+<!-- ModalComponent.vue -->
+<template>
+  <div v-if="isModalImageDetailOpen" class="modal">
+    <div class="modal-content" @click.stop>
+      <div class="modal-inner relative">
+        <img :src="url" alt="선택된 이미지" class="w-full h-full object-cover aspect-w-1 aspect-h-1 p-1">
+        <span class="close absolute" @click="closeImageDetailModal()">&times;</span>
+      </div>
+      <button @click="closeImageDetailModal">Close</button>
+    </div>
+  </div>
+</template>
+
+<script>
+
+export default {
+  props: ['selectedImageUrl', 'isModalImageDetailOpen'],
+  data() {
+    return {
+      isModalOpen: false,
+      currentModalComponent: null,
+      url: '',
+    };
+  },
+  watch: {
+    selectedImageUrl: {
+      immediate: true,
+      handler(newVal) {
+        if (newVal) {
+          this.loadAccountDetails(newVal);
+        }
+      }
+    }
+  },
+  methods: {
+    handleModalClick(event) {
+      // 모달 배경 클릭 시 모달 닫기
+      if (event.target === this.$refs.modalContainer) {
+        this.closeImageDetailModal();
+      }
+    },
+    closeImageDetailModal() {
+      this.$emit('close-modal');
+    },
+    loadAccountDetails(selectedImageUrl){
+      this.url = selectedImageUrl;
+    }
+  },
+};
+</script>
+
+
+<style scoped>
+.modal {
+  z-index: 1000;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal-content {
+  background: #F3F4F6;
+  width: 500px;
+  max-height: 85vh;
+  overflow-y: auto;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+}
+
+.close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  cursor: pointer;
+  font-size: 24px;
+}
+
+.modal-header {
+  background-color: #f5a742;
+  color: white;
+  padding: 20px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.modal-title {
+  margin: 0;
+}
+
+.modal-body {
+    padding: 20px;
+    background-color: white;
+}
+
+button {
+  margin-top: 10px;
+  cursor: pointer;
+}
+</style>

--- a/src/components/modal/UserDetailModal.vue
+++ b/src/components/modal/UserDetailModal.vue
@@ -260,8 +260,9 @@ export default {
   background: white;
   width: 500px;
   border-radius: 8px;
+  max-height: 85vh;
+  overflow-y: auto;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
-  max-height: 100vh; /* 최대 높이 설정 */
   overflow-y: auto; /* 세로 스크롤 활성화 */
 }
 

--- a/src/views/AdminList.vue
+++ b/src/views/AdminList.vue
@@ -6,7 +6,7 @@
     </div>
 
     <div class="container mb-4" style="width: calc(100% - 40px); margin: 10px;">
-      <table class="table border border-gray-200 border-2" style="width: calc(100% - 20px); margin: 10px">
+      <table class="table border border-gray-200" style="width: calc(100% - 20px); margin: 10px">
         <tbody>
           <tr>
             <th class="py-2 border border-gray-300 bg-gray-200"

--- a/src/views/ComplaintList.vue
+++ b/src/views/ComplaintList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="">
-    <div class="mx-3 mt-3 p-1 bg-white rounded-md shadow-md">
-        <div class="text-4xl font-bold p-3 border-gray-300"> 문의 게시글 리스트 </div>
+    <div class="m-3 p-1 bg-white rounded-md shadow-md flex">
+      <div class="text-4xl font-bold p-3">문의 게시글 리스트 </div>  
     </div>
     <div class="m-2 grid grid-cols-4">
       <div class="bg-white m-2 p-2 rounded-md py-5 px-4 shadow-md">
@@ -13,7 +13,7 @@
             </svg>
           </div>
         </div>
-          <div class="m-5 text-5xl font-bold text-center"> {{allCount}}개</div>
+          <div class="m-5 text-4xl font-bold text-center"> {{allCount}}개</div>
       </div>
       
       <div class="bg-white m-2 p-2 rounded-md py-5 px-4 shadow-md">
@@ -23,7 +23,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 9.75a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375m-13.5 3.01c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.184-4.183a1.14 1.14 0 0 1 .778-.332 48.294 48.294 0 0 0 5.83-.498c1.585-.233 2.708-1.626 2.708-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
           </svg>
         </div>
-          <div class="m-5 text-5xl font-bold text-center"> {{statusCount[0]}}개</div>
+          <div class="m-5 text-4xl font-bold text-center"> {{statusCount[0]}}개</div>
       </div>
       
       <div class="bg-white m-2 p-2 rounded-md py-5 px-4 shadow-md">
@@ -33,7 +33,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 0 1 1.037-.443 48.282 48.282 0 0 0 5.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
           </svg>
         </div>
-          <div class="m-5 text-5xl font-bold text-center"> {{statusCount[1]}}개</div>
+          <div class="m-5 text-4xl font-bold text-center"> {{statusCount[1]}}개</div>
       </div>
 
       <div class="bg-white m-2 p-2 rounded-md py-5 px-4 shadow-md">
@@ -42,38 +42,37 @@
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-gray-500">
             <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
           </svg>
-          
         </div>
-          <div class="m-5 text-5xl font-bold text-center"> {{statusCount[1]}}개</div>
+          <div class="m-5 text-4xl font-bold text-center"> {{statusCount[1]}}개</div>
       </div>
     </div>
 
     <div class="m-3 p-1 bg-white rounded-md shadow-md">
-        <div class="container mb-4 border-b-2 border-gray-300 " style="width: calc(100% - 40px); margin: 10px;">
-            <table class="table border-gray-400 border-2" style="width: calc(100%); margin: 10px;"> 
+        <div class="container mb-4 mx-[10px]" style="width: calc(100% - 40px);">
+            <table style="width: calc(100% - 20px); margin: 10px"> 
                 <tbody>
                     <tr>
-                        <th class="p-2 border-2 border-orange-400 text-xl text-center" style="background-color: #F5A742; width: 20%; color: white;" >게시글 번호</th>
-                        <td class="p-2 border-2 border-gray-300" style="width: 80%;">
-                            <input type="text" v-model="complaintId" class="w-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 focus:border-transparent shadow-sm text-base"> <!-- 너비 조정 -->
+                        <th class="p-2 border-2 border-orange-400 text-xl text-center" style="background-color: #F5A742; width: 20%; color: white;">게시글 번호</th>
+                        <td class="px-2 border-2 border-gray-300" style="width: 80%;">
+                            <input type="text" v-model="complaintId" class="w-full text-base outline-none hover:bg-gray-100 active:bg-gray-200">
                         </td>
                     </tr>
                     <tr>
                         <th class="p-2 border-2 border-orange-400 text-xl text-center" style="background-color: #F5A742; width: 20%; color: white;">고객 이름</th>
                         <td class="px-2 border-2 border-gray-300" style="width: 80%;">
-                            <input type="text" v-model="name" class="w-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 focus:border-transparent shadow-sm text-base">
+                            <input type="text" v-model="name" class="w-full text-base outline-none hover:bg-gray-100 active:bg-gray-200">
                         </td>
                     </tr>
                     <tr>
                         <th class="p-2 border-2 border-orange-400 text-xl text-center" style="background-color: #F5A742; width: 20%; color: white;">게시글 제목</th>
                         <td class="px-2 border-2 border-gray-300" style="width: 80%;">
-                            <input type="text" v-model="title" class="w-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 focus:border-transparent shadow-sm text-base">
+                            <input type="text" v-model="title" class="w-full text-base outline-none hover:bg-gray-100 active:bg-gray-200">
                         </td>
                     </tr>
                     <tr>
                         <th class="p-2 border-2 border-orange-400 text-xl text-center" style="background-color: #F5A742; width: 20%; color: white;">답변 여부</th>
                         <td class="px-2 border-2 border-gray-300" style="width: 80%;">
-                        <select class="custom-select m-1 p-1 border rounded-md" v-model="status">
+                        <select v-model="status" class="m-1 p-1 rounded-md w-48 outline-none">
                             <option :value="null">--선택--</option>
                             <option value="BEFORE">답변 없음</option>
                             <option value="REPLY">답변 완료</option>
@@ -82,11 +81,18 @@
                     </tr>
                 </tbody>
             </table>
-            <button 
-                class="bg-custom-F5A742 hover:bg-orange-600 text-white font-bold py-3 px-6 rounded" 
-                style="width: 200px; text-align: center; margin-left: calc(100% - 210px); margin-bottom: 10px;"
-                @click="searchComplaint"
-            >검색</button>
+            <div class="flex justify-between">
+              <div style="margin-left: 10px; margin-top: 30px">
+                  <span>페이지 크기:</span>
+                  <select v-model="pageSize" @change="changePageSize" class="outline-none">
+                      <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
+                  </select>
+              </div>
+              <div style="text-align: right; margin-bottom: 10px; margin-right: 10px;">
+                  <button @click="resetInputs" class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded w-[120px] mr-3"> 입력값 초기화 </button>
+                  <button @click="searchComplaint" class="bg-custom-F5A742 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded w-[120px]"> 검색 </button>
+              </div>
+            </div>
         </div>
 
         <div class="container" style="width: calc(100% - 40px); margin: 10px">
@@ -94,12 +100,12 @@
               class="divide-y divide-gray-200"
               style="width: calc(100% - 20px); margin: 10px"
             >
-              <thead class="bg-gray-100">
+              <thead class="bg-gray-50">
                 <tr>
-                  <th scope="col" class="px-6 py-3 w-1/6 text-center text-xl font-medium text-gray-500 uppercase tracking-wider">No</th>
-                  <th scope="col" class="px-6 py-3 w-1/6 text-center text-xl font-medium text-gray-500 uppercase tracking-wider">이름</th>
-                  <th scope="col" class="px-6 py-3 w-3/6 text-center text-xl font-medium text-gray-500 uppercase tracking-wider">제목</th>
-                  <th scope="col" class="px-6 py-3 w-1/6 text-center text-xl font-medium text-gray-500 uppercase tracking-wider">답변 상태</th>
+                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">No</th>
+                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">이름</th>
+                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">제목</th>
+                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">답변 상태</th>
                 </tr>
               </thead>
               <tbody class="bg-white divide-y divide-gray-200">
@@ -138,6 +144,7 @@ export default {
   data() {
     return {
       complaintList: [],
+      pageSizeOptions: [10, 25, 50, 100],
       pageSize: 10,
       currentPage: 0,
       searchValue: '',
@@ -216,6 +223,10 @@ export default {
       this.currentPage = pageNum;
       this.loadComplaint();
     },
+    changePageSize(event) {
+        this.pageSize = parseInt(event.target.value);
+        this.searchComplaint();
+    },
     formatRole(status) {
       switch (status) {
         case "BEFORE":
@@ -228,14 +239,14 @@ export default {
     },
     getStatusColor(status) {
       return {
-        'px-6 py-4 whitespace-nowrap text-center text-lg text-red-400': status === '답변 없음', // BEFORE 상태일 때 글자색을 빨간색으로 설정
-        'px-6 py-4 whitespace-nowrap text-center text-lg text-green-400 bg-gray-100': status === '답변 완료' // REPLY 상태일 때 글자색을 초록색으로 설정
+        'px-6 py-4 whitespace-nowrap text-red-400': status === '답변 없음', // BEFORE 상태일 때 글자색을 빨간색으로 설정
+        'px-6 py-4 whitespace-nowrap text-green-400 bg-gray-100': status === '답변 완료' // REPLY 상태일 때 글자색을 초록색으로 설정
       };
     },
     getStatusBackground(status){
       return {
-        'px-6 py-4 whitespace-nowrap text-center text-lg ': status === '답변 없음', // BEFORE 상태일 때 글자색을 빨간색으로 설정
-        'px-6 py-4 whitespace-nowrap text-center text-lg bg-gray-100': status === '답변 완료' // REPLY 상태일 때 글자색을 초록색으로 설정
+        'px-6 py-4 whitespace-nowrap': status === '답변 없음', // BEFORE 상태일 때 글자색을 빨간색으로 설정
+        'px-6 py-4 whitespace-nowrap bg-gray-100': status === '답변 완료' // REPLY 상태일 때 글자색을 초록색으로 설정
       };
     },
     ComplaintDetail(complaintId) {
@@ -251,11 +262,18 @@ export default {
       this.isModalComplaintDetailOpen = false;
       console.log(this.isModalComplaintDetailOpen);
     },
+    resetInputs() {
+        this.complaintId = null;
+        this.name = null;
+        this.title = null;
+        this.status = null;
+        this.searchComplaint();
+    },
   },
 }
 
 </script>
 
-<style lang="scss" scoped>
+<style>
 
 </style>

--- a/src/views/CouponList.vue
+++ b/src/views/CouponList.vue
@@ -1,46 +1,93 @@
 <template>
-    <div class="min-h-screen flex flex-col items-center">
-        <div class="container border-4">
-            CouponList
+    <div class="">
+        <div class="mx-3 mt-3 p-1 bg-white rounded-md shadow-md">
+            <div class="text-4xl font-bold p-3 border-gray-300"> 쿠폰 리스트 </div>
         </div>
         
+        <div class="m-2 grid grid-cols-4">
+            <div class="bg-white m-2 p-2 rounded-md py-5 px-4 shadow-md">
+              <div class="flex">
+                <div class="text-xl font-bold text-gray-500 mr-2">총 쿠폰</div>
+                <div>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-gray-500">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 6v.75m0 3v.75m0 3v.75m0 3V18m-9-5.25h5.25M7.5 15h3M3.375 5.25c-.621 0-1.125.504-1.125 1.125v3.026a2.999 2.999 0 0 1 0 5.198v3.026c0 .621.504 1.125 1.125 1.125h17.25c.621 0 1.125-.504 1.125-1.125v-3.026a2.999 2.999 0 0 1 0-5.198V6.375c0-.621-.504-1.125-1.125-1.125H3.375Z" />
+                    </svg>
+                </div>
+              </div>
+                <div class="m-5 text-4xl font-bold text-center"> 30개</div>
+            </div>
+            
+            <div class="bg-white m-2 p-2 rounded-md py-5 px-4 shadow-md">
+              <div class="flex">
+                <div class="text-xl font-bold text-gray-500 mr-2">발행 중인 쿠폰</div>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-gray-500">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6Z" />
+                </svg>
+              </div>
+                <div class="m-5 text-4xl font-bold text-center"> 30개</div>
+            </div>
+            
+            <div class="bg-white m-2 p-2 rounded-md py-5 px-4 shadow-md">
+              <div class="flex">
+                <div class="text-xl font-bold text-gray-500 mr-2">사용한 쿠폰 / 발급 쿠폰</div>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-gray-500">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 0 1-1.043 3.296 3.745 3.745 0 0 1-3.296 1.043A3.745 3.745 0 0 1 12 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 0 1-3.296-1.043 3.745 3.745 0 0 1-1.043-3.296A3.745 3.745 0 0 1 3 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 0 1 1.043-3.296 3.746 3.746 0 0 1 3.296-1.043A3.746 3.746 0 0 1 12 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 0 1 3.296 1.043 3.746 3.746 0 0 1 1.043 3.296A3.745 3.745 0 0 1 21 12Z" />
+                </svg>
+              </div>
+              <div class="flex m-5 justify-center">
+                  <div class="text-4xl font-bold text-right"> 30</div>
+                  <div class="mt-3 text-xl font-bold text-center"> /120개</div>
+              </div>
+            </div>
+      
+            <div class="bg-white m-2 p-2 rounded-md py-5 px-4 shadow-md">
+              <div class="flex">
+                <div class="text-xl font-bold text-gray-500 mr-2">만료 임박 쿠폰</div>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-gray-500">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                </svg>
+              </div>
+                <div class="m-5 text-4xl font-bold text-center"> 30개</div>
+            </div>
+        </div>
+
+        <div class="m-3 p-1 bg-white rounded-md shadow-md">
         <div class="container mb-4" style="width: calc(100% - 40px); margin: 10px; border-bottom: 1px solid #ccc;">
             <table class="table border-gray-200 border-2" style="width: calc(100%); margin: 10px;"> 
                 <tbody>
                     <tr>
-                        <th class="py-2 border border-gray-300" style="background-color: #F5A742; width: 20%; color: white;" >쿠폰명</th>
-                        <td class="px-4 border border-gray-300" style="width: 80%;">
-                            <input type="text" id="searchName" v-model="searchName" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-32 shadow-sm sm:text-sm border-gray-300 rounded-md"> <!-- 너비 조정 -->
+                        <th class="p-2 border-2 border-orange-400 text-xl text-center" style="background-color: #F5A742; width: 20%; color: white;" >쿠폰명</th>
+                        <td class="px-2 border-2 border-gray-300 " style="width: 80%;">
+                            <input type="text" id="searchName" v-model="searchName" class="w-full text-base outline-none hover:bg-gray-100 active:bg-gray-200">
                         </td>
                     </tr>
                     <tr>
-                        <th class="py-2 border border-gray-300" style="background-color: #F5A742; width: 20%; color: white;">쿠폰코드</th>
-                        <td class="px-4 border border-gray-300" style="width: 80%;">
-                            <input type="text" id="searchCode" v-model="searchCode" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-32 shadow-sm sm:text-sm border-gray-300 rounded-md">
+                        <th class="p-2 border-2 border-orange-400 text-xl text-center" style="background-color: #F5A742; width: 20%; color: white;">쿠폰코드</th>
+                        <td class="px-2 border border-gray-300" style="width: 80%;">
+                            <input type="text" id="searchCode" v-model="searchCode" class="w-full text-base outline-none hover:bg-gray-100 active:bg-gray-200">
                         </td>
                     </tr>
                     <tr>
-                        <th class="py-2 border border-gray-300" style="background-color: #F5A742; width: 20%; color: white;">시작일</th>
-                        <td class="px-4 border border-gray-300" style="width: 80%;">
+                        <th class="p-2 border-2 border-orange-400 text-xl text-center" style="background-color: #F5A742; width: 20%; color: white;">시작일</th>
+                        <td class="px-2 border border-gray-300" style="width: 80%;">
                             <div class="flex">
-                                <input type="date" id="searchStartDate" v-model="searchStartDate" class="mt-1 mr-2 focus:ring-indigo-500 focus:border-indigo-500 block w-32 shadow-sm sm:text-sm border-gray-300 rounded-md">
-                                <!-- <input type="time" id="searchStartTime" v-model="searchStartTime" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-32 shadow-sm sm:text-sm border-gray-300 rounded-md"> -->
+                                <input type="date" id="searchStartDate" v-model="searchStartDate" class="m-1 p-1 rounded-md w-48 outline-none hover:bg-gray-100 active:bg-gray-200">
                             </div>
                         </td>
                     </tr>
                     <tr>
-                        <th class="py-2 border border-gray-300" style="background-color: #F5A742; width: 20%; color: white;">마감일</th>
-                        <td class="px-4 border border-gray-300" style="width: 80%;">
+                        <th class="p-2 border-2 border-orange-400 text-xl text-center" style="background-color: #F5A742; width: 20%; color: white;">마감일</th>
+                        <td class="px-2 border border-gray-300" style="width: 80%;">
                             <div class="flex">
-                                <input type="date" id="searchEndDate" v-model="searchEndDate" class="mt-1 mr-2 focus:ring-indigo-500 focus:border-indigo-500 block w-32 shadow-sm sm:text-sm border-gray-300 rounded-md">
-                                <!-- <input type="time" id="searchEndTime" v-model="searchEndTime" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-32 shadow-sm sm:text-sm border-gray-300 rounded-md"> -->
+                                <input type="date" id="searchEndDate" v-model="searchEndDate" class="m-1 p-1 rounded-md w-48 outline-none">
                             </div>
                         </td>
                     </tr>
                     <tr>
-                        <th class="py-2 border border-gray-300" style="background-color: #F5A742; width: 20%; color: white;">쿠폰 상태</th>
-                        <td class="px-4 border border-gray-300" style="width: 80%;">
-                            <select id="searchCouponStatus" v-model="searchCouponStatus">
+                        <th class="p-2 border-2 border-orange-400 text-xl text-center" style="background-color: #F5A742; width: 20%; color: white;">쿠폰 상태</th>
+                        <td class="px-2 border border-gray-300" style="width: 80%;">
+                            <select id="searchCouponStatus" v-model="searchCouponStatus" class="m-1 p-1 rounded-md w-48 outline-none">
                               <option value="발급">발급</option>
                               <option value="삭제">삭제</option>
                               <option value="발행">발행</option>
@@ -52,13 +99,19 @@
                     </tr>
                 </tbody>
             </table>
-            <button 
-                class="bg-custom-F5A742 hover:bg-orange-600 text-white font-bold py-3 px-6 rounded" 
-                style="width: 200px; text-align: center; margin-left: calc(100% - 210px); margin-bottom: 10px;"
-                @click="searchCoupons"
-            >검색</button>
+            <div class="flex justify-between">
+                <div style="margin-left: 10px; margin-top: 30px">
+                    <span>페이지 크기:</span>
+                    <select v-model="pageSize" @change="changePageSize" class="outline-none">
+                        <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
+                    </select>
+                </div>
+                <div style="text-align: right; margin-bottom: 10px; margin-right: 10px;">
+                    <button @click="resetInputs" class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded w-[120px] mr-3"> 입력값 초기화 </button>
+                    <button @click="searchCoupons" class="bg-custom-F5A742 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded w-[120px]"> 검색 </button>
+                </div>
+              </div>
         </div>
-
         
         <div class="container mb-4" style="width: calc(100% - 40px); margin: 10px;">
             <table class="divide-y divide-gray-200" style="width: calc(100%); margin: 10px;" >
@@ -116,16 +169,16 @@
                 </tbody>
             </table>
 
-            <div class="flex justify-between" style="width: calc(100% - 20px); margin: 10px;">
-                <button class="bg-custom-F5A742 hover:bg-orange-700 text-white font-bold py-3 px-6 rounded" style="width: 200px; text-align: center; margin-left: calc(100% - 400px);" @click="openSelectUserModal">발행</button>
-                <SelectUserModal :isModalSelectUserOpen="isModalSelectUserOpen" :selectedCoupons="selectedCoupons" @close-modal="isModalSelectUserOpen = false"/>
-                <button class="bg-custom-F5A742 hover:bg-orange-700 text-white font-bold py-3 px-6 rounded" style="width: 200px; text-align: center; margin-left: 10px;" @click="deleteCoupon">삭제</button>
-            </div>
         </div>
-
-        <!-- 페이지네이션 컴포넌트 추가 -->
-        <PaginationComponent :currentPage="currentPage" :totalPages="totalPageCount" @page-change="changePage" />
         
+        <!-- 페이지네이션 컴포넌트 추가 -->
+        <PaginationComponent :currentPage="currentPage" :totalPages="totalPageCount" @page-change="changePage"/>
+        <div class="flex justify-between" style="width: calc(100% - 20px); margin: 10px;">
+            <button class="bg-custom-F5A742 hover:bg-orange-700 text-white font-bold py-3 px-6 rounded" style="width: 200px; text-align: center; margin-left: calc(100% - 400px);" @click="openSelectUserModal">발행</button>
+            <SelectUserModal :isModalSelectUserOpen="isModalSelectUserOpen" :selectedCoupons="selectedCoupons" @close-modal="isModalSelectUserOpen = false"/>
+            <button class="bg-custom-F5A742 hover:bg-orange-700 text-white font-bold py-3 px-6 rounded" style="width: 200px; text-align: center; margin-left: 10px;" @click="deleteCoupon">삭제</button>
+        </div>
+    </div>
     </div>
 </template>
 
@@ -147,8 +200,8 @@ export default {
             searchStartDate: '',
             searchEndDate: '',
             searchCouponStatus: '',
-
-            pageSize: 2,
+            pageSizeOptions: [10, 25, 50, 100],
+            pageSize: 10,
             currentPage: 0,
             searchValue: '',
             isLastPage: false,
@@ -163,7 +216,6 @@ export default {
         this.loadCoupons();
     },
     methods:{
-
         async loadCoupons(){
             try{
                 const params = {
@@ -205,7 +257,7 @@ export default {
         },
         changePage(pageNum) {
             this.currentPage = pageNum;
-            this.loadCoupons();
+            this.searchCoupons();
         },
         openSelectUserModal() {
             console.log(this.selectedCoupons);
@@ -300,6 +352,14 @@ export default {
                 console.error('쿠폰 삭제 중 오류 발생', error);
                 alert("삭제 불가능한 쿠폰 입니다.")
             }
+        },
+        resetInputs() {
+            this.searchName = null;
+            this.searchCode = null;
+            this.searchStartDate = null;
+            this.searchEndDate = null;
+            this.searchCouponStatus = null;
+            this.searchCoupons();
         },
     },
 }

--- a/src/views/CouponList.vue
+++ b/src/views/CouponList.vue
@@ -173,6 +173,7 @@
         
         <!-- 페이지네이션 컴포넌트 추가 -->
         <PaginationComponent :currentPage="currentPage" :totalPages="totalPageCount" @page-change="changePage"/>
+
         <div class="flex justify-between" style="width: calc(100% - 20px); margin: 10px;">
             <button class="bg-custom-F5A742 hover:bg-orange-700 text-white font-bold py-3 px-6 rounded" style="width: 200px; text-align: center; margin-left: calc(100% - 400px);" @click="openSelectUserModal">발행</button>
             <SelectUserModal :isModalSelectUserOpen="isModalSelectUserOpen" :selectedCoupons="selectedCoupons" @close-modal="isModalSelectUserOpen = false"/>
@@ -207,9 +208,7 @@ export default {
             isLastPage: false,
             isLoading: false,
             totalPageCount: 0,
-
             isModalSelectUserOpen: false,
-
         }
     },
     created(){
@@ -221,22 +220,7 @@ export default {
                 const params = {
                 page: this.currentPage,
                 size: this.pageSize,
-                
                 }
-                console.log("data 호출");
-                const access_token = localStorage.getItem('access_token');
-                const headers = access_token ? {Authorization: `Bearer ${access_token}`} : {};
-                const response = await axios.get(`${process.env.VUE_APP_API_BASE_URL}/coupon/list`, { headers, params });
-                this.couponList = response.data.result.data;
-                this.totalPageCount = response.data.result.totalPage;
-                console.log(this.couponList);
-                console.log(this.totalPageCount);
-            }catch(error){
-                console.log(error);
-            }
-        },
-        async searchCoupons(){
-            try{
                 console.log("search 호출");
                 const access_token = localStorage.getItem('access_token');
                 const headers = access_token ? {Authorization: `Bearer ${access_token}`} : {};
@@ -244,20 +228,29 @@ export default {
                         name: this.searchName,
                         code: this.searchCode,
                         startDate: this.searchStartDate,
-                        endDate: this.searchEndDate,
+                        endDate: this.searchEndDate,    
                         couponStatus: this.searchCouponStatus,
                     };
-                const response = await axios.post(`${process.env.VUE_APP_API_BASE_URL}/coupon/search`, data ,{headers});
-                this.couponList = response.data.result.data;
-                this.totalPageCount = response.data.result.totalPage;
-                console.log(this.couponList);
+                const response = await axios.post(`${process.env.VUE_APP_API_BASE_URL}/coupon/search`, data, { headers, params });
+                this.couponList = response.data.result.data.content;
+                this.totalPageCount = response.data.result.data.totalPages;
+                console.log(response);
             }catch(error){
                 console.log(error);
             }
         },
+        searchCoupons(){
+            this.couponList = [];
+            this.totalPageCount = '';
+            this.loadCoupons();
+        },
         changePage(pageNum) {
             this.currentPage = pageNum;
-            this.searchCoupons();
+            this.loadCoupons();
+        },
+        changePageSize(event) {
+            this.pageSize = parseInt(event.target.value);
+            this.loadCoupons();
         },
         openSelectUserModal() {
             console.log(this.selectedCoupons);

--- a/src/views/UserList.vue
+++ b/src/views/UserList.vue
@@ -1,149 +1,168 @@
 <template>
-    <div class="container mb-4 border border-gray-300 bg-white"
-        style="width: calc(100% - 40px); margin: 10px; border-color: #CCCCCC;">
-        <div class="text-white font-bold text-center mb-4" style="color: #f5a742; font-size: 3rem; margin-top: 50px">
-            고객 계정 조회
+    <div class="">
+        <div class=" m-3 p-1 bg-white rounded-md shadow-md flex">
+            <div class="text-4xl font-bold p-3 border-gray-300">고객 계정 조회</div>  
         </div>
 
-        <div class="container mb-4" style="width: calc(100% - 40px); margin: 10px;">
-            <table class="table border border-gray-200 border-2" style="width: calc(100% - 20px); margin: 10px">
-                <tbody>
-                    <tr>
-                        <th class="py-2 border border-gray-300 bg-gray-200"
-                            style="background-color: #f5a742; width: 20%; color: white">
-                            고객명
-                        </th>
-                        <td class="px-4 border-t border-gray-300" style="width: 80%;">
-                            <input type="text" id="searchName" v-model="searchName"
-                                class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-48 px-3 py-1.5 rounded-md border-gray-300 shadow-sm sm:text-sm"
-                                style="background-color: #DDDDDD; height: 2rem; width:50%; margin-top: 0.5rem; margin-bottom: 0.5rem;">
-                        </td>
-                    </tr>
-                    <tr>
-                        <th class="py-2 border border-gray-300 bg-gray-200"
-                            style="background-color: #f5a742; width: 20%; color: white">
-                            이메일
-                        </th>
-                        <td class="px-4 border-t border-gray-300" style="width: 80%;">
-                            <input type="text" id="searchEmail" v-model="searchEmail"
-                                class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-48 px-3 py-1.5 rounded-md border-gray-300 shadow-sm sm:text-sm"
-                                style="background-color: #DDDDDD; height: 2rem; width:50%; margin-top: 0.5rem; margin-bottom: 0.5rem;">
-                        </td>
-                    </tr>
-                    <tr>
-                        <th class="py-2 border border-gray-300 bg-gray-200"
-                            style="background-color: #f5a742; width: 20%; color: white">
-                            생일
-                        </th>
-                        <td class="px-4 border border-gray-300" style="width: 80%;">
-                            <div class="flex">
-                                <input type="date" id="searchBirthDate" v-model="searchBirthDate"
-                                    class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block px-3 py-1.5 rounded-md border-gray-300 shadow-sm sm:text-sm"
-                                    style="background-color: #dddddd; height: 2rem; width: 25%; margin-top: 0.5rem; margin-bottom: 0.5rem;">
-                            </div>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th class="py-2 border border-gray-300 bg-gray-200"
-                            style="background-color: #f5a742; width: 20%; color: white">
-                            성별
-                        </th>
-                        <td class="px-4 border-t border-gray-300" style="width: 80%;">
-                            <select id="searchRole" v-model="searchGender"
-                                class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 flex-1 block px-3 py-1 rounded-md border-gray-300 shadow-sm sm:text-sm"
-                                style="background-color: #dddddd; height: 2rem; width: 25%; margin-top: 0.5rem; margin-bottom: 0.5rem;">
-                                <option value="남자">남자</option>
-                                <option value="여자">여자</option>
-                            </select>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th class="py-2 border border-gray-300 bg-gray-200"
-                            style="background-color: #f5a742; width: 20%; color: white">
-                            등급
-                        </th>
-                        <td class="px-4 border-t border-gray-300" style="width: 80%;">
-                            <select id="searchGrade" v-model="searchGrade"
-                                class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 flex-1 block px-3 py-1 rounded-md border-gray-300 shadow-sm sm:text-sm"
-                                style="background-color: #dddddd; height: 2rem; width: 25%; margin-top: 0.5rem; margin-bottom: 0.5rem;">
-                                <option value="VVIP">VVIP</option>
-                                <option value="VIP">VIP</option>
-                                <option value="GOLD">GOLD</option>
-                                <option value="SILVER">SILVER</option>
-                            </select>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-            <div style="text-align: right; margin-bottom: 10px;">
-                <button @click="resetInputs"
-                    class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded">
-                    입력값 초기화
-                </button>
-            </div>
-            <div class="flex justify-between">
-                <div style="margin-left: 10px; margin-top: 30px">
-                    <span>페이지 크기:</span>
-                    <select v-model="pageSize" @change="changePageSize">
-                        <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
-                    </select>
+        <div class="m-2 grid grid-cols-4">
+            <div class="bg-white m-2 p-2 rounded-md py-5 px-4 shadow-md">
+              <div class="flex">
+                <div class="text-xl font-bold text-gray-500 mr-2">총 고객</div>
+                <div>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-gray-500">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
+                    </svg>
                 </div>
-                <button @click="loadUsers"
-                    class="bg-custom-F5A742 hover:bg-orange-600 text-white font-bold py-3 px-6 rounded"
-                    style="width: 200px; text-align: center; margin-bottom: 10px;">
-                    검색
-                </button>
+              </div>
+                <div class="m-5 text-4xl font-bold text-center"> 30명</div>
             </div>
-        </div>
-        <div class="container mb-4 border border-gray-300 bg-white"
-            style="width: calc(100% - 40px); margin: 10px; border-color: #CCCCCC;">
-            <table class="divide-y divide-gray-200" style="width: calc(100% - 20px); margin: 10px">
-                <thead class="bg-gray-50">
-                    <tr>
-                        <th scope="col"
-                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">No
-                        </th>
-                        <th scope="col"
-                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">고객명
-                        </th>
-                        <th scope="col"
-                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">이메일
-                        </th>
-                        <th scope="col"
-                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">생년월일
-                        </th>
-                        <th scope="col"
-                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">전화번호
-                        </th>
-                        <th scope="col"
-                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">성별
-                        </th>
-                        <th scope="col"
-                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">등급
-                        </th>
-                    </tr>
-                </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
-                    <tr v-for="(user, index) in userList" :key="user.id" @click="openUserDetailModal(user.id)"
-                        style="cursor: pointer;">
-                        <td class="px-6 py-4 whitespace-nowrap">{{ currentPage * pageSize + index + 1 }}</td>
-                        <td class="px-6 py-4 whitespace-nowrap">{{ user.name }}</td>
-                        <td class="px-6 py-4 whitespace-nowrap">{{ user.email }}</td>
-                        <td class="px-6 py-4 whitespace-nowrap">{{ user.birthDate }}</td>
-                        <td class="px-6 py-4 whitespace-nowrap">{{ user.phoneNumber }}</td>
-                        <td class="px-6 py-4 whitespace-nowrap">{{ user.gender === "MALE" ? '남성' : '여성' }}</td>
-                        <td class="px-6 py-4 whitespace-nowrap">{{ user.grade }}</td>
-                    </tr>
-                </tbody>
-            </table>
-            <div class="modal-content" @click.stop>
-                <div class="modal-inner">
-                    <UserDetailModal :isModalUserDetailOpen="isModalUserDetailOpen" :selectedUserId="selectedUserId"
-                        @close-modal="isModalUserDetailOpen = false" />
+            
+            <div class="bg-white m-2 p-2 rounded-md py-5 px-4 shadow-md">
+              <div class="flex">
+                <div class="text-xl font-bold text-gray-500 mr-2">신규 회원</div>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-gray-500">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3 19.235v-.11a6.375 6.375 0 0 1 12.75 0v.109A12.318 12.318 0 0 1 9.374 21c-2.331 0-4.512-.645-6.374-1.766Z" />
+                </svg>
+              </div>
+                <div class="m-5 text-4xl font-bold text-center"> 30명</div>
+            </div>
+            
+            <div class="bg-white m-2 p-2 rounded-md py-5 px-4 shadow-md">
+              <div class="flex">
+                <div class="text-xl font-bold text-gray-500 mr-2">템플릿 1</div>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-gray-500">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 0 1-1.043 3.296 3.745 3.745 0 0 1-3.296 1.043A3.745 3.745 0 0 1 12 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 0 1-3.296-1.043 3.745 3.745 0 0 1-1.043-3.296A3.745 3.745 0 0 1 3 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 0 1 1.043-3.296 3.746 3.746 0 0 1 3.296-1.043A3.746 3.746 0 0 1 12 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 0 1 3.296 1.043 3.746 3.746 0 0 1 1.043 3.296A3.745 3.745 0 0 1 21 12Z" />
+                </svg>
+              </div>
+              <div class="flex m-5 justify-center">
+                  <div class="text-4xl font-bold text-right"> 30</div>
+                  <div class="mt-3 text-xl font-bold text-center"> /120개</div>
+              </div>
+            </div>
+      
+            <div class="bg-white m-2 p-2 rounded-md py-5 px-4 shadow-md">
+              <div class="flex">
+                <div class="text-xl font-bold text-gray-500 mr-2">만료 임박 쿠폰</div>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-gray-500">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                </svg>
+              </div>
+                <div class="m-5 text-4xl font-bold text-center"> 30개</div>
+            </div>
+          </div>
+
+        <div class="m-3 p-1 bg-white rounded-md shadow-md">
+            <div class="container mb-4 mx-[10px]" style="width: calc(100% - 40px);">
+                <table style="width: calc(100% - 20px); margin: 10px">
+                    <tbody>
+                        <tr>
+                            <th class="p-2 border border-orange-400 text-xl text-center" style="background-color: #F5A742; width: 20%; color: white;">고객 이름</th>
+                            <td class="px-4 border border-gray-400" style="width: 80%;">
+                                <input type="text" id="searchName" v-model="searchName" class="w-full text-base outline-none hover:bg-gray-100 active:bg-gray-200">
+                            </td>
+                        </tr>
+                        <tr>
+                            <th class="p-2 border border-orange-400 text-xl text-center" style="background-color: #F5A742; width: 20%; color: white;">이메일</th>
+                            <td class="px-4 border border-gray-400" style="width: 80%;">
+                                <input type="text" id="searchEmail" v-model="searchEmail" class="w-full text-base outline-none hover:bg-gray-100 active:bg-gray-200">
+                            </td>
+                        </tr>
+                        <tr>
+                            <th class="p-2 border border-orange-400 text-xl text-center" style="background-color: #F5A742; width: 20%; color: white;">생년월일</th>
+                            <td class="px-4 border border-gray-400" style="width: 80%;">
+                                <div class="flex">
+                                    <input type="date" id="searchBirthDate" v-model="searchBirthDate" class="m-1 p-1 rounded-md w-48 outline-none">
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th class="p-2 border border-orange-400 text-xl text-center" style="background-color: #F5A742; width: 20%; color: white;">성별</th>
+                            <td class="px-4 border border-gray-400" style="width: 80%;">
+                                <select id="searchRole" v-model="searchGender" class="m-1 p-1 rounded-md w-48 outline-none">
+                                    <option value="남자">남자</option>
+                                    <option value="여자">여자</option>
+                                </select>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th class="p-2 border border-orange-400 text-xl text-center" style="background-color: #F5A742; width: 20%; color: white;">등급</th>
+                            <td class="px-4 border border-gray-400" style="width: 80%;">
+                                <select id="searchGrade" v-model="searchGrade" class="m-1 p-1 rounded-md w-48 outline-none">
+                                    <option value="VVIP">VVIP</option>
+                                    <option value="VIP">VIP</option>
+                                    <option value="GOLD">GOLD</option>
+                                    <option value="SILVER">SILVER</option>
+                                </select>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                
+                <div class="flex justify-between">
+                    <div style="margin-left: 10px; margin-top: 30px">
+                        <span>페이지 크기:</span>
+                        <select v-model="pageSize" @change="changePageSize" class="outline-none">
+                            <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
+                        </select>
+                    </div>
+                    <div style="text-align: right; margin-bottom: 10px; margin-right: 10px;">
+                        <button @click="resetInputs" class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded w-[120px] mr-3"> 입력값 초기화 </button>
+                        <button @click="loadUsers" class="bg-custom-F5A742 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded w-[120px]"> 검색 </button>
+                    </div>
                 </div>
+
+
+                    
             </div>
-            <PaginationComponent :currentPage="currentPage" :totalPages="totalPageCount" @page-change="changePage"
-                style="margin-bottom: 25px;" />
+            <div class="container mb-4 border-gray-300 bg-white"
+                style="width: calc(100% - 40px); margin: 10px; border-color: #CCCCCC;">
+                <table class="divide-y divide-gray-200" style="width: calc(100% - 20px); margin: 10px">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th scope="col"
+                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">No
+                            </th>
+                            <th scope="col"
+                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">고객명
+                            </th>
+                            <th scope="col"
+                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">이메일
+                            </th>
+                            <th scope="col"
+                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">생년월일
+                            </th>
+                            <th scope="col"
+                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">전화번호
+                            </th>
+                            <th scope="col"
+                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">성별
+                            </th>
+                            <th scope="col"
+                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">등급
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-200">
+                        <tr v-for="(user, index) in userList" :key="user.id" @click="openUserDetailModal(user.id)"
+                            style="cursor: pointer;">
+                            <td class="px-6 py-4 whitespace-nowrap">{{ currentPage * pageSize + index + 1 }}</td>
+                            <td class="px-6 py-4 whitespace-nowrap">{{ user.name }}</td>
+                            <td class="px-6 py-4 whitespace-nowrap">{{ user.email }}</td>
+                            <td class="px-6 py-4 whitespace-nowrap">{{ user.birthDate }}</td>
+                            <td class="px-6 py-4 whitespace-nowrap">{{ user.phoneNumber }}</td>
+                            <td class="px-6 py-4 whitespace-nowrap">{{ user.gender === "MALE" ? '남성' : '여성' }}</td>
+                            <td class="px-6 py-4 whitespace-nowrap">{{ user.grade }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <div class="modal-content" @click.stop>
+                    <div class="modal-inner">
+                        <UserDetailModal :isModalUserDetailOpen="isModalUserDetailOpen" :selectedUserId="selectedUserId"
+                            @close-modal="isModalUserDetailOpen = false" />
+                    </div>
+                </div>
+                <PaginationComponent :currentPage="currentPage" :totalPages="totalPageCount" @page-change="changePage" style="margin-bottom: 25px;" />
+            </div>
         </div>
     </div>
 </template>
@@ -250,15 +269,9 @@ export default {
             this.searchGrade = '';
             this.loadUsers();
         },
-
     },
-
-    setup() {
-
-
-        return {}
-    }
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style>
+</style>


### PR DESCRIPTION
## #️⃣연관된 이슈

> * #53 

## 📝작업 내용

- 쿠폰리스트 디자인 수정
- 고객 리스트 디자인 수정
- 쿠폰리스트 통계 컨테이너 추가
- 고객 리스트 통계 컨테이너 추가
- 게시글 상세 조회 모달에서 사진 클릭시 사진 확대 모달창 생성
- 각 리스트 페이지에 페이지 크기 옵션 추가
- 각 리스트 페이지에 입력값 초기화 기능 추가

### 스크린샷 (선택)

![image](https://github.com/Catch-team/Catch_FE/assets/78871184/04521233-e346-4b06-a46b-7df0e58d7b8a)

![image](https://github.com/Catch-team/Catch_FE/assets/78871184/b243e4b5-1305-45ed-afaa-96ea16096351)

![image](https://github.com/Catch-team/Catch_FE/assets/78871184/e7877552-7668-49cb-8640-6ea329a8b74c)

